### PR TITLE
Fix summary account numbers and amount decimal representation

### DIFF
--- a/bai_file_processor/parsers.py
+++ b/bai_file_processor/parsers.py
@@ -8,7 +8,7 @@ from .models import \
     Group, GroupHeader, GroupTrailer, \
     AccountIdentifier, AccountTrailer, Account, \
     TransactionDetail, Summary
-from .utils import parse_date, parse_time, parse_type_code
+from .utils import parse_date, parse_time, parse_type_code, parse_amount
 
 
 # ABSTRACTION
@@ -206,7 +206,7 @@ class TransactionDetailParser(BaseSingleParser):
 
     head_fields_config = [
         ('type_code', parse_type_code),
-        ('amount', int),
+        ('amount', parse_amount),
         ('funds_type', FundsType),
     ]
 
@@ -251,7 +251,7 @@ class AccountIdentifierParser(BaseSingleParser):
     ]
     summary_fields_config = [
         ('type_code', parse_type_code),
-        ('amount', int),
+        ('amount', parse_amount),
         ('item_count', int),
         ('funds_type', FundsType),
     ]

--- a/bai_file_processor/utils.py
+++ b/bai_file_processor/utils.py
@@ -1,6 +1,7 @@
 import datetime
 import re
 import warnings
+from decimal import Decimal
 
 from .constants import TypeCode, TypeCodeLevel, TypeCodes
 
@@ -75,6 +76,20 @@ def parse_type_code(value):
     return type_code
 
 
+def parse_amount(value):
+    """Parse a BAI2 amount string as Decimal, supporting both integer ('10000')
+    and explicit-decimal ('1000.50') formats sent by different banks."""
+    return Decimal(value)
+
+
+def format_amount(raw_amount):
+    """Convert a raw BAI2 amount (smallest currency unit, e.g. cents) to a
+    decimal dollar value by dividing by 100."""
+    if raw_amount is None:
+        return None
+    return Decimal(str(raw_amount)) / Decimal('100')
+
+
 def convert_to_string(value):
     if value is None:
         return ''
@@ -87,7 +102,7 @@ def process_account_summary(summary):
         'BAI Code': summary.type_code.code,
         'Level': summary.type_code.level.value,
         'Description': summary.type_code.description,
-        'Amount': summary.amount,
+        'Amount': format_amount(summary.amount),
         'Count': summary.item_count,
         'Fund Type': summary.funds_type,
         'Availability': summary.availability
@@ -96,9 +111,10 @@ def process_account_summary(summary):
 
 def process_account_header(header):
     summary_list = []
-    summary_items = header.summary_items
-    for account_summary in summary_items:
+    for account_summary in header.summary_items:
         summary_data = process_account_summary(account_summary)
+        summary_data['Customer Account Number'] = header.customer_account_number
+        summary_data['Currency'] = header.currency
         summary_list.append(summary_data)
     return summary_list
 
@@ -113,7 +129,7 @@ def process_account_transactions(identifier, transactions):
             'Transaction': transaction.type_code.transaction.value,
             'Level': transaction.type_code.level.value,
             'Description': transaction.type_code.description,
-            'Amount': transaction.amount,
+            'Amount': format_amount(transaction.amount),
             'Fund Type': transaction.funds_type,
             'Availability': transaction.availability,
             'Bank Reference': transaction.bank_reference,

--- a/tests/test_bai2.py
+++ b/tests/test_bai2.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import warnings
+from decimal import Decimal
 from unittest import TestCase
 
 from bai_file_processor import bai_parser
@@ -113,6 +114,43 @@ class ParseTestCase(TestCase):
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, 'transactions.csv')))
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, 'summary.csv')))
 
+
+    def test_summary_includes_account_number_and_currency(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.bai2', delete=False) as f:
+            f.write(_SAMPLE_BAI2)
+            tmp_path = f.name
+        try:
+            _, _, _, summaries = bai_parser.extract_bai_components(tmp_path)
+            self.assertTrue(len(summaries) > 0)
+            for s in summaries:
+                self.assertIn('Customer Account Number', s)
+                self.assertIn('Currency', s)
+                self.assertEqual(s['Customer Account Number'], '77777777')
+                self.assertEqual(s['Currency'], 'GBP')
+        finally:
+            os.unlink(tmp_path)
+
+    def test_transaction_amount_is_decimal_divided_by_100(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.bai2', delete=False) as f:
+            f.write(_SAMPLE_BAI2)
+            tmp_path = f.name
+        try:
+            _, _, transactions, summaries = bai_parser.extract_bai_components(tmp_path)
+            # transaction amount 001 -> Decimal('0.01')
+            self.assertTrue(len(transactions) > 0)
+            self.assertEqual(transactions[0]['Amount'], Decimal('0.01'))
+            # summary amount 10000 -> Decimal('100.00')
+            self.assertTrue(len(summaries) > 0)
+            self.assertEqual(summaries[0]['Amount'], Decimal('100.00'))
+        finally:
+            os.unlink(tmp_path)
+
+    def test_parse_amount_handles_explicit_decimal(self):
+        from bai_file_processor.utils import parse_amount, format_amount
+        self.assertEqual(parse_amount('10000'), Decimal('10000'))
+        self.assertEqual(parse_amount('1000.50'), Decimal('1000.50'))
+        self.assertEqual(format_amount(10000), Decimal('100.00'))
+        self.assertIsNone(format_amount(None))
 
     def test_parse_type_code_158_ach_reversal_credit(self):
         bai2_with_158 = (


### PR DESCRIPTION
Closes #2

## What was wrong

**Account/routing numbers missing from summary CSV**: `process_account_header` in `utils.py` had access to the `AccountIdentifier` header (which carries `customer_account_number` and `currency`) but never included those fields in the summary dicts it returned. Every row in `summary.csv` was missing the account number and currency columns.

**Decimals skipped on amount fields**: BAI2 amounts are in the smallest currency unit (cents for USD), so `10000` in the file means `$100.00`. The library was surfacing raw integers with no decimal conversion. Additionally, the bare `int()` parser would crash with a `ValueError` on amounts like `1000.50` that some non-standard bank exports include.

## What changed

- `utils.py` — `process_account_header` now injects `Customer Account Number` and `Currency` into every summary dict.
- `utils.py` — added `parse_amount()` (uses `Decimal`, handles both `'10000'` and `'1000.50'`) and `format_amount()` (divides by 100 to convert cents → dollars). Both output functions (`process_account_summary`, `process_account_transactions`) now call `format_amount` so CSV amounts show `100.00` not `10000`.
- `parsers.py` — `TransactionDetailParser` and `AccountIdentifierParser` now use `parse_amount` instead of `int` for amount fields.
- `tests/test_bai2.py` — three new tests: account number present in summary, decimal amount conversion, explicit-decimal `parse_amount` input.

## Test results

33 tests pass, 2 skipped (missing fixture files, pre-existing), 0 failures.